### PR TITLE
add white noise type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export const NoiseTypes: {
   white: 'white',
 }
 
-export type NoiseType = 'perlin' | 'simplex' | 'cell' | 'curl'
+export type NoiseType = 'perlin' | 'simplex' | 'cell' | 'curl' | 'white'
 
 export const MappingTypes: {
   [key: string]: string


### PR DESCRIPTION
I think the `white` noise type is missing from the definition. This PR adds it in :)