### PR TITLE
fix: children should refresh the parent

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import {
   MeshLambertMaterialProps,
   MeshStandardMaterialProps,
 } from '@react-three/fiber'
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef, useEffect, useLayoutEffect } from 'react'
 import mergeRefs from 'react-merge-refs'
 import {
   DepthProps,
@@ -69,14 +69,14 @@ const LayerMaterial = React.forwardRef<
   LAYERS.LayerMaterial,
   React.PropsWithChildren<LayerMaterialProps & Omit<AllMaterialProps, 'color'>>
 >(({ children, ...props }, forwardRef) => {
-  const ref = React.useRef<LAYERS.LayerMaterial>(null!)
-
-  React.useLayoutEffect(() => {
-    ref.current.layers = (ref.current as any).__r3f.objects
-    ref.current.refresh()
-  }, [children])
-
+  const ref = React.useRef<LAYERS.LayerMaterial & { __hasRefreshed: boolean }>(null!)
   const [args, otherProps] = useMemo(() => getLayerMaterialArgs(props), [props])
+
+  useLayoutEffect(() => {
+    ref.current.layers = (ref.current as any).__r3f.objects
+    // This will fire before all children, allow possible children to refresh again
+    ref.current.__hasRefreshed = false
+  })
 
   return (
     <layerMaterial args={[args]} ref={mergeRefs([ref, forwardRef])} {...otherProps}>
@@ -98,49 +98,63 @@ function getNonUniformArgs(props: any) {
   ] as any
 }
 
+let hasRefreshed = false
+function useRefresh<T>({ mode, visible, type, mapping, map, axes }: any) {
+  const ref = useRef<T>()
+  useEffect(() => {
+    const parent: LAYERS.LayerMaterial & { __hasRefreshed: boolean } = (ref.current as any)?.__r3f?.parent
+    // Refresh parent material on mount
+    if (parent && parent.__hasRefreshed == false) {
+      parent.refresh()
+      parent.__hasRefreshed = true
+    }
+  }, [mode, visible, type, mapping, map, axes])
+  return ref
+}
+
 const Depth = React.forwardRef<LAYERS.Depth, DepthProps>((props, forwardRef) => {
-  //@ts-ignore
-  return <depth_ args={getNonUniformArgs(props)} ref={forwardRef} {...props} />
+  const ref = useRefresh<LAYERS.Depth>(props)
+  return <depth_ args={getNonUniformArgs(props)} ref={mergeRefs([ref, forwardRef])} {...props} />
 }) as React.ForwardRefExoticComponent<DepthProps & React.RefAttributes<LAYERS.Depth>>
 
-const Color = React.forwardRef<LAYERS.Color, ColorProps>((props, ref) => {
-  //@ts-ignore
-  return <color_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Color = React.forwardRef<LAYERS.Color, ColorProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Color>(props)
+  return <color_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<ColorProps & React.RefAttributes<LAYERS.Color>>
 
-const Noise = React.forwardRef<LAYERS.Noise, NoiseProps>((props, ref) => {
-  //@ts-ignore
-  return <noise_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Noise = React.forwardRef<LAYERS.Noise, NoiseProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Noise>(props)
+  return <noise_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<NoiseProps & React.RefAttributes<LAYERS.Noise>>
 
-const Fresnel = React.forwardRef<LAYERS.Fresnel, FresnelProps>((props, ref) => {
-  //@ts-ignore
-  return <fresnel_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Fresnel = React.forwardRef<LAYERS.Fresnel, FresnelProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Fresnel>(props)
+  return <fresnel_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<FresnelProps & React.RefAttributes<LAYERS.Fresnel>>
 
-const Gradient = React.forwardRef<LAYERS.Gradient, GradientProps>((props, ref) => {
-  //@ts-ignore
-  return <gradient_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Gradient = React.forwardRef<LAYERS.Gradient, GradientProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Gradient>(props)
+  return <gradient_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<GradientProps & React.RefAttributes<LAYERS.Gradient>>
 
-const Matcap = React.forwardRef<LAYERS.Matcap, MatcapProps>((props, ref) => {
-  //@ts-ignore
-  return <matcap_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Matcap = React.forwardRef<LAYERS.Matcap, MatcapProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Matcap>(props)
+  return <matcap_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<MatcapProps & React.RefAttributes<LAYERS.Matcap>>
 
-const Texture = React.forwardRef<LAYERS.Texture, TextureProps>((props, ref) => {
-  //@ts-ignore
-  return <texture_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Texture = React.forwardRef<LAYERS.Texture, TextureProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Texture>(props)
+  return <texture_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<TextureProps & React.RefAttributes<LAYERS.Texture>>
 
-const Displace = React.forwardRef<LAYERS.Displace, DisplaceProps>((props, ref) => {
-  //@ts-ignore
-  return <displace_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Displace = React.forwardRef<LAYERS.Displace, DisplaceProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Displace>(props)
+  return <displace_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<DisplaceProps & React.RefAttributes<LAYERS.Displace>>
 
-const Normal = React.forwardRef<LAYERS.Normal, NormalProps>((props, ref) => {
-  //@ts-ignore
-  return <normal_ ref={ref} args={getNonUniformArgs(props)} {...props} />
+const Normal = React.forwardRef<LAYERS.Normal, NormalProps>((props, forwardRef) => {
+  const ref = useRefresh<LAYERS.Normal>(props)
+  return <normal_ ref={mergeRefs([ref, forwardRef])} args={getNonUniformArgs(props)} {...props} />
 }) as React.ForwardRefExoticComponent<NormalProps & React.RefAttributes<LAYERS.Normal>>
 
 export { DebugLayerMaterial, LayerMaterial, Depth, Color, Noise, Fresnel, Gradient, Matcap, Texture, Displace, Normal }


### PR DESCRIPTION
lamina will re-create the shader on every render because "children" is not a stable reference. children should rather inform lamina on mount, and when certain props have changed that it must refresh. this of course would duplicate refresh multiple times once you're dealing with multiple layers — this draft would try to work against that.