### PR TITLE
[feat] Add copy vanilla js button

### DIFF
--- a/src/debug.tsx
+++ b/src/debug.tsx
@@ -14,7 +14,7 @@ import { DataItem, StoreType } from 'leva/dist/declarations/src/types'
 import React, { useEffect, useMemo, useState } from 'react'
 import mergeRefs from 'react-merge-refs'
 import { getLayerMaterialArgs, getUniform } from './utils/Functions'
-import { serializedLayersToJSX } from './utils/ExportUtils'
+import { serializedLayersToJSX, serializedLayersToJS } from './utils/ExportUtils'
 import * as LAYERS from './vanilla'
 import { Color, ColorRepresentation, TextureLoader } from 'three'
 import { LayerMaterialProps, ShadingType, ShadingTypes } from './types'
@@ -79,6 +79,11 @@ const DebugLayerMaterial = React.forwardRef<
         const serialized = ref.current.layers.map((l) => l.serialize())
         const jsx = serializedLayersToJSX(serialized, ref.current.serialize())
         navigator.clipboard.writeText(jsx)
+      }),
+      'Copy JS': button(() => {
+        const serialized = ref.current.layers.map(l => l.serialize());
+        const js = serializedLayersToJS(serialized, ref.current.serialize());
+        navigator.clipboard.writeText(js);
       }),
     },
     { store }

--- a/src/utils/ExportUtils.ts
+++ b/src/utils/ExportUtils.ts
@@ -55,7 +55,7 @@ function getJSPropsFromLayer(layer: SerializedLayer) {
     const eol = '\n\t\t';
     if (key.includes('color')) {
       const v = typeof val === "string" ? val : '#' + val.getHexString();
-      props += `${key}: new THREE.Color(${JSON.stringify(v)}),${eol}`;
+      props += `${key}: ${JSON.stringify(v)},${eol}`;
     } else {
       const defaultVal = (_constructor = constructor['u_' + key]) != null ? _constructor : instance[key];
       switch (key) {

--- a/src/utils/ExportUtils.ts
+++ b/src/utils/ExportUtils.ts
@@ -43,3 +43,54 @@ export function serializedLayersToJSX(layers: SerializedLayer[], material: Seria
 
   return jsx
 }
+
+function getJSPropsFromLayer(layer: SerializedLayer) {
+  // @ts-ignore
+  const constructor = LAYERS[layer.constructor];
+  const instance = new constructor();
+  let props = '\t';
+  let entries = Object.entries(layer.properties);
+  entries.forEach(([key, val], idx) => {
+    var _constructor;
+    const eol = '\n\t\t';
+    if (key.includes('color')) {
+      const v = typeof val === "string" ? val : '#' + val.getHexString();
+      props += `${key}: new THREE.Color(${JSON.stringify(v)}),${eol}`;
+    } else {
+      const defaultVal = (_constructor = constructor['u_' + key]) != null ? _constructor : instance[key];
+      switch (key) {
+        case 'name':
+          if (val !== layer.constructor) props += `${key}: ${JSON.stringify(val)},${eol}`;
+          break;
+          
+          case 'visible':
+            if (!val) props += `${key}:${JSON.stringify(val)},${eol}`;
+            break;
+            
+          default:
+            if (val !== defaultVal) props += `${key}: ${JSON.stringify(val)},${eol}`;
+            break;
+        }
+      }
+  });
+  return props;
+}
+
+export function serializedLayersToJS(layers: SerializedLayer[], material: SerializedLayer){
+  const materialProps = getJSPropsFromLayer(material);
+  const jsLayers = `${layers.map(l => {
+    return `new ${l.constructor}({
+      ${getJSPropsFromLayer(l)}
+      })`
+  }).join(',\n\t\t')}`
+
+  const js = `
+  new LayerMaterial({
+    ${materialProps}
+    layers: [
+      ${jsLayers}
+    ]
+  })`
+
+  return js;
+}


### PR DESCRIPTION
Adds a button to the debugger to copy the vanilla js code and some util fns to support the serializing.

Let me know what you think!

Examples from the configurator (formatting varies depending on where you paste):

**JSX:**
```jsx

    <LayerMaterial color={16711422} name={"Monkey w/ freckles"}>
      <Depth near={-0.06800000000000028} far={5} origin={[0,0,3]} colorA={"#fe96dc"} colorB={"#68eefb"} />
	<Depth near={1} far={3} origin={[0,0,-1.3670000000000089]} colorA={"#feb600"} colorB={"#000000"} mode={"screen"} />
	<Fresnel color={"#fefefe"} power={1.9099999999999757} mode={"softlight"} />
	<Noise colorA={"#84fee9"} colorB={"#969696"} colorC={"#000000"} colorD={"#000000"} scale={50} offset={[0,0,0]} name={"noise"} mode={"lighten"} />
    </LayerMaterial>
    
```

**Vanilla JS:**
```javascript
 new LayerMaterial({
  color: new THREE.Color('#fefefe'),
  name: 'Monkey w/ freckles',

  layers: [
    new Depth({
      near: -0.06800000000000028,
      far: 5,
      origin: [0, 0, 3],
      colorA: new THREE.Color('#fe96dc'),
      colorB: new THREE.Color('#68eefb')
    }),
    new Depth({
      near: 1,
      far: 3,
      origin: [0, 0, -1.3670000000000089],
      colorA: new THREE.Color('#feb600'),
      colorB: new THREE.Color('#000000'),
      mode: 'screen'
    }),
    new Fresnel({
      color: new THREE.Color('#fefefe'),
      power: 1.9099999999999757,
      mode: 'softlight'
    }),
    new Noise({
      colorA: new THREE.Color('#84fee9'),
      colorB: new THREE.Color('#969696'),
      colorC: new THREE.Color('#000000'),
      colorD: new THREE.Color('#000000'),
      scale: 50,
      offset: [0, 0, 0],
      name: 'noise',
      mode: 'lighten'
    })
  ]
});

 ```