### PR TITLE
fix: react-merge-refs => useImperativeHandle

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "glsl-tokenizer": "^2.1.5",
     "lamina": "^1.1.22",
     "leva": "^0.9.20",
-    "react-merge-refs": "^2.0.1",
     "three-custom-shader-material": "^4.0.0"
   },
   "peerDependencies": {
@@ -99,9 +98,6 @@
       "optional": true
     },
     "react-dom": {
-      "optional": true
-    },
-    "react-merge-refs": {
       "optional": true
     }
   }

--- a/src/debug.tsx
+++ b/src/debug.tsx
@@ -11,8 +11,7 @@ import { createRoot } from 'react-dom/client'
 
 import { button, LevaPanel, useControls, useCreateStore } from 'leva'
 import { DataItem, StoreType } from 'leva/dist/declarations/src/types'
-import React, { useEffect, useMemo, useState } from 'react'
-import { mergeRefs } from 'react-merge-refs'
+import React, { useEffect, useImperativeHandle, useMemo, useState } from 'react'
 import { getLayerMaterialArgs, getUniform } from './utils/Functions'
 import { serializedLayersToJSX, serializedLayersToJS } from './utils/ExportUtils'
 import * as LAYERS from './vanilla'
@@ -68,6 +67,7 @@ const DebugLayerMaterial = React.forwardRef<
       [key: string]: any
     }
   >(null!)
+  useImperativeHandle(forwardRef, () => ref.current)
   const store = useCreateStore()
   const [layers, setLayers] = React.useState<{ [name: string]: any[] }>({})
   const [path, setPath] = React.useState(['', ''])
@@ -200,7 +200,7 @@ const DebugLayerMaterial = React.forwardRef<
       {Object.entries(layers).map(([name, layers], i) => (
         <DynamicLeva key={`${name} ~${i}`} name={name} layers={layers} store={store} setUpdate={setPath} />
       ))}
-      <layerMaterial args={[args]} ref={mergeRefs([ref, forwardRef])} {...otherProps}>
+      <layerMaterial args={[args]} ref={ref} {...otherProps}>
         {children}
       </layerMaterial>
     </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,7 @@ import {
   MeshLambertMaterialProps,
   MeshStandardMaterialProps,
 } from '@react-three/fiber'
-import React, { useMemo } from 'react'
-import { mergeRefs } from 'react-merge-refs'
+import React, { useMemo, useImperativeHandle } from 'react'
 import {
   DepthProps,
   ColorProps,
@@ -70,6 +69,7 @@ const LayerMaterial = React.forwardRef<
   React.PropsWithChildren<LayerMaterialProps & Omit<AllMaterialProps, 'color'>>
 >(({ children, ...props }, forwardRef) => {
   const ref = React.useRef<LAYERS.LayerMaterial>(null!)
+  useImperativeHandle(forwardRef, () => ref.current)
 
   React.useLayoutEffect(() => {
     ref.current.layers = (ref.current as any).__r3f.objects
@@ -79,7 +79,7 @@ const LayerMaterial = React.forwardRef<
   const [args, otherProps] = useMemo(() => getLayerMaterialArgs(props), [props])
 
   return (
-    <layerMaterial args={[args]} ref={mergeRefs([ref, forwardRef])} {...otherProps}>
+    <layerMaterial args={[args]} ref={ref} {...otherProps}>
       {children}
     </layerMaterial>
   )


### PR DESCRIPTION
Fixes #43 by preferring React's built-in [`React.useImperativeHandle`](https://reactjs.org/docs/hooks-reference.html#useimperativehandle) to combine refs from [`React.forwardRef`](https://reactjs.org/docs/react-api.html#reactforwardref).